### PR TITLE
refactor: Remove unnecessary storage permissions and function

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
     <queries>
         <!-- Intent for viewing images -->

--- a/src/screens/FlowEditorScreen.js
+++ b/src/screens/FlowEditorScreen.js
@@ -116,47 +116,6 @@ const getTextColorForBackground = hexColor => {
   return luminance > 186 ? 'black' : 'white';
 };
 
-const requestStoragePermission = async () => {
-  if (Platform.OS !== 'android') {
-    return true;
-  }
-
-  try {
-    let permissionsToRequest;
-    if (Platform.Version >= 33) {
-      permissionsToRequest = [
-        PermissionsAndroid.PERMISSIONS.READ_MEDIA_IMAGES,
-        PermissionsAndroid.PERMISSIONS.READ_MEDIA_VIDEO,
-      ];
-    } else {
-      permissionsToRequest = [
-        PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE,
-      ];
-    }
-
-    const statuses = await PermissionsAndroid.requestMultiple(
-      permissionsToRequest,
-    );
-
-    const allGranted = Object.values(statuses).every(
-      status => status === PermissionsAndroid.RESULTS.GRANTED,
-    );
-
-    if (allGranted) {
-      return true;
-    } else {
-      Alert.alert(
-        'Permission Denied',
-        'Storage permission is required to attach files.',
-      );
-      return false;
-    }
-  } catch (err) {
-    console.warn(err);
-    return false;
-  }
-};
-
 const FlowEditorScreen = ({ route, navigation }) => {
   const { flowId, flowName } = route.params;
   const { t } = useTranslation();
@@ -654,8 +613,6 @@ const FlowEditorScreen = ({ route, navigation }) => {
 
   const handleAttachFile = async () => {
     Keyboard.dismiss();
-    const hasPermission = await requestStoragePermission();
-    if (!hasPermission) return;
 
     try {
       const result = await pick({


### PR DESCRIPTION
Removes the `READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO` permissions from `AndroidManifest.xml` as they were causing rejections from the Google Play Store.

Also removes the unused `requestStoragePermission` function and its call from `FlowEditorScreen.js`, as the file pickers in use do not require any permissions.