### PR TITLE
v2.7.0 fix: Sanitize zip filename in flow export

### DIFF
--- a/src/screens/FlowListScreen.js
+++ b/src/screens/FlowListScreen.js
@@ -271,9 +271,8 @@ const FlowListScreen = ({ navigation }) => {
       const exportTempDir = `${RNFS.TemporaryDirectoryPath}/export_${
         flow.id
       }_${Date.now()}`;
-      const zipPath = `${RNFS.TemporaryDirectoryPath}/${flow.name.replace(
-        /\s/g,
-        '_',
+      const zipPath = `${RNFS.TemporaryDirectoryPath}/${sanitizeFilename(
+        flow.name.replace(/\s/g, '_'),
       )}.zip`;
 
       try {


### PR DESCRIPTION
## Summary
Follow-up to #109. The zip path in flow export was built from \`flow.name\` with only whitespace replacement, so a flow named e.g. \`../something\` produced a path outside the temp directory and caused the export to fail.

This fix routes the zip filename through the same \`sanitizeFilename\` helper introduced in #109, so such names export safely as \`_something.zip\`.

Caught during real-device testing for v2.7.0; folding into the same release rather than cutting v2.7.1.

## Test plan
- [ ] Create a flow named \`../testname\` → export as zip → file is generated successfully (as \`_testname.zip\` or similar)
- [ ] Normal flow names export unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)