### PR TITLE
hotfix: close migrateAddColumnIfMissing arrow function body

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -329,6 +329,7 @@ export const migrateAddColumnIfMissing = (table, column, type) => {
       err => reject(err),
     );
   });
+};
 
 export const initDB = lang => {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Missing trailing `};` from #115 refactor caused Metro release bundling to fail with "'import' and 'export' may only appear at the top level. (333:0)" and broke the v2.9.0 release CI (GitHub Android + Xcode Cloud iOS both failed on JS bundling).